### PR TITLE
fix: resolve duplicate key issue in gallery pagination

### DIFF
--- a/app/api/gallery/route.ts
+++ b/app/api/gallery/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { galleryImages, imageLikes } from "@/lib/schema";
-import { desc, eq, count, sql } from "drizzle-orm";
+import { desc, eq, count, sql, lt } from "drizzle-orm";
 import { put } from "@vercel/blob";
 
 export async function GET(request: NextRequest) {
@@ -41,8 +41,9 @@ export async function GET(request: NextRequest) {
       .limit(limit + 1); // Get one extra to check if there are more
 
     if (cursor) {
-      // For cursor-based pagination with aggregation, we need a different approach
-      // For now, let's skip cursor pagination when using aggregation - this can be improved later
+      // Parse cursor date and add proper filtering
+      const cursorDate = new Date(cursor);
+      query.where(lt(galleryImages.createdAt, cursorDate));
     }
 
     const results = await query;

--- a/hooks/use-gallery.ts
+++ b/hooks/use-gallery.ts
@@ -113,10 +113,14 @@ export const useGallery = (userId?: string) => {
     },
   });
 
+  // Flatten and deduplicate images by ID to prevent duplicate keys
   const images = data?.pages?.flatMap((page) => page.images) || [];
+  const deduplicatedImages = images.filter((image, index, array) => 
+    array.findIndex(img => img.id === image.id) === index
+  );
 
   return {
-    images,
+    images: deduplicatedImages,
     isLoading,
     error,
     hasNextPage,


### PR DESCRIPTION
- Implement proper cursor-based pagination in gallery API
- Add lt() condition to filter images by creation date cursor
- Add deduplication logic in useGallery hook as safeguard
- Prevent React duplicate key errors during infinite scroll

Fixes the issue where scrolling would load duplicate images causing 'Encountered two children with the same key' errors