### PR TITLE
fix: typo Utec Ventures

### DIFF
--- a/components/sections/judges/judges-section.tsx
+++ b/components/sections/judges/judges-section.tsx
@@ -25,7 +25,7 @@ export default function JudgesSection() {
     {
       name: "Sebastian Ruiz",
       image: "/sebastian-ruiz.png",
-      title: "Program Lead at UTech Ventures",
+      title: "Program Lead at UTEC Ventures",
       linkedin: "https://www.linkedin.com/in/sruizdecastillam/",
     },
     {


### PR DESCRIPTION
It should say 'Program Lead at UTEC Ventures' instead of 'Program Lead at UTech Ventures'